### PR TITLE
Bug Fix for Handling None Gradients

### DIFF
--- a/grokfast.py
+++ b/grokfast.py
@@ -14,10 +14,10 @@ def gradfilter_ma(
     trigger: bool = False, # For ablation study.
 ) -> Dict[str, deque]:
     if grads is None:
-        grads = {n: deque(maxlen=window_size) for n, p in m.named_parameters() if p.requires_grad}
+        grads = {n: deque(maxlen=window_size) for n, p in m.named_parameters() if p.requires_grad and p.grad is not None}
 
     for n, p in m.named_parameters():
-        if p.requires_grad:
+        if p.requires_grad and p.grad is not None:
             grads[n].append(p.grad.data.detach()) # .cpu())
 
             # Modify the gradients.
@@ -40,10 +40,10 @@ def gradfilter_ema(
     lamb: float = 2.0,
 ) -> Dict[str, torch.Tensor]:
     if grads is None:
-        grads = {n: p.grad.data.detach() for n, p in m.named_parameters() if p.requires_grad}
+        grads = {n: p.grad.data.detach() for n, p in m.named_parameters() if p.requires_grad and p.grad is not None}
 
     for n, p in m.named_parameters():
-        if p.requires_grad:
+        if p.requires_grad and p.grad is not None:
             grads[n] = grads[n] * alpha + p.grad.data.detach() * (1 - alpha)
             p.grad.data = p.grad.data + grads[n] * lamb
 


### PR DESCRIPTION
While trying out your amazing idea, I noticed a bug when I initialized some parameters, but do not actually used them in training. The error _AttributeError: 'NoneType' object has no attribute 'data'_ occurs because **p.grad** is **None** for these unused parameters. This happens since they are not involved in the training process.

I know it is a small contribution, so feel free to reject this pull request if it does not fit your requirements.